### PR TITLE
Add dependency for node-sass module which is mandatory for gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
     "gulp-watch": "^5.0.1",
+    "node-sass": "^4.13.0",
     "run-sequence": "^2.2.1",
     "undescores-for-npm": "^1.0.0"
   },


### PR DESCRIPTION
# Description

Add dependency for node-sass package which is mandatory for gulp-sass to work.

## Fixes

'npm install' script getting broken.